### PR TITLE
Small UI change to the store plans page

### DIFF
--- a/resources/views/store/plans.blade.php
+++ b/resources/views/store/plans.blade.php
@@ -55,7 +55,11 @@
                         <p class="card-text">
                             <ul class="list-unstyled">
                                 <li>RAM <span class="float-right">{{ $plan->ram }} MB</span></li>
-                                <li>CPU <span class="float-right">{{ $plan->cpu }}%</span></li>
+                                @if ($plan->cpu === 0)
+                                    <li>CPU <span class="float-right">Uncapped</span></li>
+                                @else
+                                    <li>CPU <span class="float-right">{{$plan->cpu }}%</span></li>
+                                @endif
                                 <li>Disk <span class="float-right">{{ $plan->disk }} MB</span></li>
                                 <li>Databases <span class="float-right">{{ $plan->databases }}</span></li>
                                 <li>Backups <span class="float-right">{{ $plan->backups }}</span></li>


### PR DESCRIPTION
a little bugfix/feature made the code show uncapped if the CPU % for a plan if it is set to 0% meaning it is uncapped and else it'll show the percentage